### PR TITLE
Prevent NPE on log line. Use monotonically increasing time for alarm …

### DIFF
--- a/org.eclipse.paho.android.service/src/main/java/org/eclipse/paho/android/service/AlarmPingSender.java
+++ b/org.eclipse.paho.android.service/src/main/java/org/eclipse/paho/android/service/AlarmPingSender.java
@@ -24,6 +24,8 @@ import android.os.AsyncTask;
 import android.os.Build;
 import android.os.PowerManager;
 import android.os.PowerManager.WakeLock;
+import android.os.SystemClock;
+import android.support.annotation.NonNull;
 import android.util.Log;
 
 import org.eclipse.paho.client.mqttv3.IMqttActionListener;
@@ -101,19 +103,20 @@ class AlarmPingSender implements MqttPingSender {
 
     @Override
     public void schedule(long delayInMilliseconds) {
-        long nextAlarmInMilliseconds = System.currentTimeMillis() + delayInMilliseconds;
+
+        long nextAlarmInMilliseconds = SystemClock.elapsedRealtime() + delayInMilliseconds;
         Log.d(TAG, "Schedule next alarm at " + nextAlarmInMilliseconds);
         AlarmManager alarmManager = (AlarmManager) service.getSystemService(Service.ALARM_SERVICE);
         if (Build.VERSION.SDK_INT >= 23) {
             // In SDK 23 and above, dosing will prevent setExact, setExactAndAllowWhileIdle will force
             // the device to run this task whilst dosing.
             Log.d(TAG, "Alarm scheule using setExactAndAllowWhileIdle, next: " + delayInMilliseconds);
-            alarmManager.setExactAndAllowWhileIdle(AlarmManager.RTC_WAKEUP, nextAlarmInMilliseconds, pendingIntent);
+            alarmManager.setExactAndAllowWhileIdle(AlarmManager.ELAPSED_REALTIME_WAKEUP, nextAlarmInMilliseconds, pendingIntent);
         } else if (Build.VERSION.SDK_INT >= 19) {
             Log.d(TAG, "Alarm scheule using setExact, delay: " + delayInMilliseconds);
-            alarmManager.setExact(AlarmManager.RTC_WAKEUP, nextAlarmInMilliseconds, pendingIntent);
+            alarmManager.setExact(AlarmManager.ELAPSED_REALTIME_WAKEUP, nextAlarmInMilliseconds, pendingIntent);
         } else {
-            alarmManager.set(AlarmManager.RTC_WAKEUP, nextAlarmInMilliseconds, pendingIntent);
+            alarmManager.set(AlarmManager.ELAPSED_REALTIME_WAKEUP, nextAlarmInMilliseconds, pendingIntent);
         }
     }
 

--- a/org.eclipse.paho.android.service/src/main/java/org/eclipse/paho/android/service/MqttConnection.java
+++ b/org.eclipse.paho.android.service/src/main/java/org/eclipse/paho/android/service/MqttConnection.java
@@ -17,6 +17,7 @@ import android.content.Context;
 import android.os.Bundle;
 import android.os.PowerManager;
 import android.os.PowerManager.WakeLock;
+import android.support.annotation.Nullable;
 import android.util.Log;
 
 import org.eclipse.paho.android.service.MessageStore.StoredMessage;
@@ -657,8 +658,12 @@ class MqttConnection implements MqttCallbackExtended {
      * @param why the exeception causing the break in communications
      */
     @Override
-    public void connectionLost(Throwable why) {
-        service.traceDebug(TAG, "connectionLost(" + why.getMessage() + ")");
+    public void connectionLost(@Nullable Throwable why) {
+        if (why != null) {
+            service.traceDebug(TAG, "connectionLost(" + why.getMessage() + ")");
+        } else {
+            service.traceDebug(TAG, "connectionLost(NO_REASON)");
+        }
         disconnected = true;
         try {
             if (!this.connectOptions.isAutomaticReconnect()) {


### PR DESCRIPTION
…manager scheduling calculations.

https://developer.android.com/training/scheduling/alarms
"There are two general clock types for alarms: "elapsed real time" and "real time clock" (RTC). Elapsed real time uses the "time since system boot" as a reference, and real time clock uses UTC (wall clock) time. This means that elapsed real time is suited to setting an alarm based on the passage of time (for example, an alarm that fires every 30 seconds) since it isn't affected by time zone/locale. The real time clock type is better suited for alarms that are dependent on current locale."

https://stackoverflow.com/a/15400014

Please make sure that the following boxes are checked before submitting your Pull Request, thank you!

- [ ] You have signed the [Eclipse ECA](https://wiki.eclipse.org/ECA)
- [ ] All of your commits have been signed-off with the correct email address (The same one that you used to sign the CLA)
- [ ] If This PR fixes an issue, that you reference the issue below. OR if this is a new issue that you are fixing straight away that you add some Description about the bug and how this will fix it.
- [ ] If this is new functionality, You have added the appropriate Unit tests.
